### PR TITLE
Is1 ma 87 generar endpoint de abandonar partida y su logica

### DIFF
--- a/tests/test_leave_game_endpoint.py
+++ b/tests/test_leave_game_endpoint.py
@@ -1,0 +1,112 @@
+import pytest
+from .test_setup import test_db
+from src.theThing.cards import crud as card_crud
+from src.theThing.cards.schemas import CardCreate, CardBase, CardUpdate
+from src.theThing.games import crud as game_crud
+from src.theThing.games.models import Game
+from src.theThing.games import schemas as game_schemas
+from src.theThing.players import crud as player_crud
+from src.theThing.players import schemas as player_schemas
+from pony.orm import db_session, rollback, commit
+from src.main import app
+from fastapi.testclient import TestClient
+
+# create a pytest fixture that populates the database
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_module():
+    game_data = game_schemas.GameCreate(
+        name="Test Game deck", min_players=4, max_players=5
+    )
+    created_game = game_crud.create_game(game_data)
+    # create the owner player
+    player_data = player_schemas.PlayerCreate(name="Player1", owner=True)
+    created_player = player_crud.create_player(player_data, created_game.id)
+
+    # create 4 players
+    player_data = player_schemas.PlayerCreate(name="Player2", owner=False)
+    created_player2 = player_crud.create_player(player_data, created_game.id)
+    player_data = player_schemas.PlayerCreate(name="Player3", owner=False)
+    created_player3 = player_crud.create_player(player_data, created_game.id)
+    player_data = player_schemas.PlayerCreate(name="Player4", owner=False)
+    created_player4 = player_crud.create_player(player_data, created_game.id)
+    player_data = player_schemas.PlayerCreate(name="Player5", owner=False)
+    created_player5 = player_crud.create_player(player_data, created_game.id)
+
+    # create a second game with just one player
+    game_data = game_schemas.GameCreate(
+        name="Test Game deck 2", min_players=4, max_players=5
+    )
+    created_game2 = game_crud.create_game(game_data)
+    player_data = player_schemas.PlayerCreate(name="Player6", owner=True)
+    created_player6 = player_crud.create_player(player_data, created_game2.id)
+    player_data = player_schemas.PlayerCreate(name="Player7", owner=False)
+    created_player7 = player_crud.create_player(player_data, created_game2.id)
+
+
+client = TestClient(app)
+
+
+def test_leave_wrong_game(test_db):
+    # test leave game with an existing player in a wrong game
+    response = client.put(
+        "/game/2/player/1/leave"
+    )  # The player with id 1 and game 2, does not exist.
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Player[1]"}
+
+
+def test_leave_game_started(test_db):
+    game = game_crud.get_full_game(2)
+    players = [player for player in game.players if player.owner is False]
+    game_crud.update_game(
+        2, game_schemas.GameUpdate(state=1)
+    )  # start the game 2, the  try to leave it
+    response = client.put(f"/game/2/player/{players[0].id}/leave")
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Game already started"}
+    # check that the player is still in the game
+    game = game_crud.get_full_game(2)
+    players_after = [player for player in game.players if player.owner is False]
+    assert len(players_after) == len(players)
+    assert players[0] in players_after
+
+
+def test_leave_game_successful(test_db):
+    game = game_crud.get_full_game(1)
+    players = [player for player in game.players if player.owner is False]
+    response = client.put(f"/game/1/player/{players[0].id}/leave")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Player {players[0].id} left game {game.id} successfully"
+    }
+    # check that the player is not in the game anymore
+    game = game_crud.get_full_game(1)
+    players_after = [player for player in game.players if player.owner is False]
+    assert len(players_after) == len(players) - 1
+    assert players[0] not in players_after
+
+
+def test_host_leaves_game(test_db):
+    game = game_crud.get_full_game(1)
+    players = [player for player in game.players if player.owner is False]
+    response = client.put(f"/game/1/player/{players[0].id}/leave")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Player {players[0].id} left game {game.id} successfully"
+    }
+    # check that the player is not in the game anymore
+    game = game_crud.get_full_game(1)
+    players_after = [player for player in game.players if player.owner is False]
+    assert len(players_after) == len(players) - 1
+    assert players[0] not in players_after
+    host = [player for player in game.players if player.owner is True][0]
+    # now the host leaves
+    response = client.put(f"/game/1/player/{host.id}/leave")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Game 1 finished successfully by host"}
+    try:
+        game = game_crud.get_full_game(1)
+    except Exception as e:
+        assert e.args[0] == "Game[1]"

--- a/tests/test_play_card_endpoint.py
+++ b/tests/test_play_card_endpoint.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .test_setup import test_db
+from .test_setup import test_db, clear_db
 from src.theThing.cards import crud as card_crud
 from src.theThing.cards.schemas import CardCreate, CardBase, CardUpdate
 from src.theThing.games import crud as game_crud


### PR DESCRIPTION
Endpoint para abandonar partida creado. 

El endpoint cumple con lo esperado, si se quiere abandonar una partida a la que uno no pertenece, no lo permite. 
Solo se pueden abandonar partidas no empezadas y si es el host el que abandona la misma se elimina y los demas jugadores tambien.

Detalles a tener en cuenta cuando el status de partida sea enviado por websocket. En los casos en que es un jugador el que abandona la partida, simplemente hay que reenviar el nuevo estado de la partida (todos sus datos y su nueva lista de jugadores). Ya que en el front el que abandono, cerrara la conexion con ambos sockets. 

Pero cuando es el host el que abandona, para su caso particular, tambien su cliente cerrara ambos sockets y no habra problema. Pero para los demas jugadores habra que notificarles por el ws que la partida fue eliminada. Asi el cliente puede cerrar el websocket y redirigirlos a la pantalla de inicio