### PR TITLE
Is1 ma 167 crear entidad para logs

### DIFF
--- a/src/theThing/games/crud.py
+++ b/src/theThing/games/crud.py
@@ -240,7 +240,7 @@ def save_log(game_id: int, log: str):
     with db_session:
         game = models.Game[game_id]
         log_dict = {
-            "date": datetime.now().strftime("%d/%m/%Y %H:%M:%S"),
+            "date": datetime.now().strftime("%d/%m/%Y %H:%M"),
             "log": log,
         }
         game.logs.append(log_dict)

--- a/src/theThing/games/crud.py
+++ b/src/theThing/games/crud.py
@@ -5,6 +5,7 @@ from src.theThing.cards.schemas import CardCreate
 from src.theThing.cards.crud import create_card
 from src.theThing.cards.static_cards import dict_of_cards
 from src.theThing.messages.schemas import MessageOut
+from datetime import datetime
 
 
 def create_game(game: schemas.GameCreate) -> schemas.GameOut:
@@ -230,3 +231,26 @@ def create_game_deck(game_id: int, players_amount: int):
                 playable=True,
             )
             create_card(new_card, game_id)
+
+
+def save_log(game_id: int, log: str):
+    """
+    This function saves a log in the game
+    """
+    with db_session:
+        game = models.Game[game_id]
+        log_dict = {
+            "date": datetime.now().strftime("%d/%m/%Y %H:%M:%S"),
+            "log": log,
+        }
+        game.logs.append(log_dict)
+        game.flush()
+
+
+def get_logs(game_id: int):
+    """
+    This function returns the logs of a game
+    """
+    with db_session:
+        game = models.Game[game_id]
+        return game.logs

--- a/src/theThing/games/endpoints.py
+++ b/src/theThing/games/endpoints.py
@@ -282,6 +282,14 @@ async def play_card(play_data: dict):
     updated_game = get_game(game_id)
     await send_game_status_to_players(game_id, updated_game)
 
+    message = (
+        f"{player.name} jugó {card.name} a {destination_name}, esperando su respuesta"
+    )
+    try:
+        save_log(game_id, message)
+    except Exception as e:
+        raise e
+    await send_action_event_to_players(game_id, message)
     return {"message": "Carta jugada con éxito"}
 
 
@@ -408,9 +416,7 @@ async def respond_to_action_card(response_data: dict):
         # Update turn status
         update_turn(game_id, TurnCreate(state=5))  # Has to be 3 in the future
         # Send event description to all players
-        message = (
-            f"{attacking_player.name} jugó {action_card.name} a {defending_player.name}"
-        )
+        message = f"{attacking_player.name} jugó con exito {action_card.name} a {defending_player.name}"
         try:
             save_log(game_id, message)
         except Exception as e:

--- a/src/theThing/games/models.py
+++ b/src/theThing/games/models.py
@@ -1,4 +1,4 @@
-from pony.orm import Required, Set, Optional, PrimaryKey
+from pony.orm import Required, Set, Optional, PrimaryKey, Json
 from src.theThing.models.db import db
 from src.theThing.players.models import Player
 from src.theThing.cards.models import Card
@@ -25,3 +25,8 @@ class Game(db.Entity):
     players = Set(Player, reverse="game")
     deck = Set(Card, reverse="game")
     chat = Set(Message)
+    logs = Optional(Json)
+
+    # on create, create a list to save in logs
+    def before_insert(self):
+        self.logs = []

--- a/src/theThing/games/schemas.py
+++ b/src/theThing/games/schemas.py
@@ -28,27 +28,6 @@ class GameInDB(GameCreate):
     turn: Optional[TurnOut] = None
     players: List[PlayerBase] = None
     deck: List[CardBase] = None
-    chat: List[MessageOut] = []
-
-    @classmethod
-    def model_validate(cls, game):
-        ordered_chat = game.chat.order_by(lambda x: x.date)
-        formatted_chat = [
-            MessageOut.model_validate(message) for message in ordered_chat
-        ]
-        return cls(
-            id=game.id,
-            name=game.name,
-            min_players=game.min_players,
-            max_players=game.max_players,
-            password=game.password,
-            state=game.state,
-            play_direction=game.play_direction,
-            turn=game.turn,
-            players=game.players,
-            deck=game.deck,
-            chat=formatted_chat,
-        )
 
 
 class GameOut(BaseModel):
@@ -61,28 +40,8 @@ class GameOut(BaseModel):
     play_direction: Optional[bool] = None
     turn: Optional[TurnOut] = None
     players: List[PlayerForGame] = []
-    chat: List[MessageOut] = []
 
     model_config = ConfigDict(from_attributes=True)
-
-    @classmethod
-    def model_validate(cls, game):
-        # first order teh chat by date
-        ordered_chat = game.chat.order_by(lambda x: x.date)
-        formatted_chat = [
-            MessageOut.model_validate(message) for message in ordered_chat
-        ]
-        return cls(
-            id=game.id,
-            name=game.name,
-            min_players=game.min_players,
-            max_players=game.max_players,
-            state=game.state,
-            play_direction=game.play_direction,
-            turn=game.turn,
-            players=game.players,
-            chat=formatted_chat,
-        )
 
 
 class GamePlayerAmount(GameBase):

--- a/src/theThing/games/socket_handler.py
+++ b/src/theThing/games/socket_handler.py
@@ -68,34 +68,29 @@ async def send_new_message_to_players(game_id: int, message: MessageOut):
 async def send_finished_game_event_to_players(game_id: int, data: dict):
     winners = data.get("winners")
     message = data.get("reason")
-    await sio.emit("game_finished", {"winners": winners, "message": message}, room="g" + str(game_id))
+    await sio.emit(
+        "game_finished",
+        {"winners": winners, "message": message},
+        room="g" + str(game_id),
+    )
 
 
-async def send_action_event_to_players(
-    game_id: int,
-    attacking_player: PlayerBase,
-    defending_player: PlayerBase,
-    action_card: CardBase,
-):
+async def send_action_event_to_players(game_id: int, message: str):
     await sio.emit(
         "action",
         data={
-            "message": attacking_player.name
-            + " le jugó la carta "
-            + action_card.name
-            + " a "
-            + defending_player.name
+            "message": message,
         },
         room="g" + str(game_id),
     )
 
 
-async def send_discard_event_to_players(game_id: int, player_name: str):
+async def send_discard_event_to_players(game_id: int, player_name: str, message: str):
     await sio.emit(
         "discard",
         {
             "player_name": player_name,
-            "message": player_name + " descartó una carta",
+            "message": message,
         },
         room="g" + str(game_id),
     )
@@ -103,22 +98,11 @@ async def send_discard_event_to_players(game_id: int, player_name: str):
 
 async def send_defense_event_to_players(
     game_id: int,
-    attacking_player: PlayerBase,
-    defending_player: PlayerBase,
-    action_card: CardBase,
-    defense_card: CardBase,
+    message: str,
 ):
     await sio.emit(
         "defense",
-        data={
-            "message": defending_player.name
-            + " se defendió del ataque de "
-            + action_card.name
-            + " jugado por "
-            + attacking_player.name
-            + " con la carta "
-            + defense_card.name
-        },
+        data={"message": message},
         room="g" + str(game_id),
     )
 

--- a/src/theThing/games/utils.py
+++ b/src/theThing/games/utils.py
@@ -464,18 +464,6 @@ def assign_hands(game: GameInDB):
             give_card_to_player(card.id, player.id, game.id)
 
 
-def calculate_winners(game_id: int):
-    """
-    Calculate the winners of the game.
-    PRE: the game exists and it is finished.
-    """
-    game = get_full_game(game_id)
-    players = game.players
-    winners = [player.name for player in players if player.alive]
-
-    return winners
-
-
 def verify_data_finish_turn(game_id: int):
     """
     Verify the integrity of finish turn data.
@@ -560,14 +548,10 @@ def calculate_winners_if_victory_declared(game_id, player_id):
         raise HTTPException(status_code=404, detail=str(e))
 
     if game.state != 1:
-        raise HTTPException(
-            status_code=422, detail="La partida no está en juego"
-        )
+        raise HTTPException(status_code=422, detail="La partida no está en juego")
 
     if player.role != 3:
-        raise HTTPException(
-            status_code=422, detail="El jugador no es La Cosa"
-        )
+        raise HTTPException(status_code=422, detail="El jugador no es La Cosa")
 
     win = True
     alive_humans = []
@@ -582,14 +566,8 @@ def calculate_winners_if_victory_declared(game_id, player_id):
                 alive_infected.append(player.name)
 
     if win:
-        result = {
-            "message": "Gana La Cosa e infectados",
-            "winners": alive_infected
-        }
+        result = {"message": "Gana La Cosa e infectados", "winners": alive_infected}
     else:
-        result = {
-            "message": "Ganan los humanos",
-            "winners": alive_humans
-        }
+        result = {"message": "Ganan los humanos", "winners": alive_humans}
 
     return result

--- a/tests/test_game_crud.py
+++ b/tests/test_game_crud.py
@@ -111,7 +111,6 @@ def test_get_all_games_in_db(test_db):
             "turn": None,
             "players": [],
             "deck": [],
-            "chat": [],
         },
         {
             "id": game2.id,
@@ -124,7 +123,6 @@ def test_get_all_games_in_db(test_db):
             "turn": None,
             "players": [],
             "deck": [],
-            "chat": [],
         },
     ]
 

--- a/tests/test_get_game_status_endpoint.py
+++ b/tests/test_get_game_status_endpoint.py
@@ -36,7 +36,6 @@ def test_get_game_success(test_db):
                 "quarantine": False,
             }
         ],
-        "chat": [],
     }
     rollback()
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,76 @@
+from .test_setup import test_db, clear_db
+from src.main import app
+from fastapi.testclient import TestClient
+from src.theThing.players.crud import get_player
+from datetime import datetime
+from src.theThing.games.crud import create_game, save_log, get_logs
+from src.theThing.games.schemas import GameCreate
+
+client = TestClient(app)
+
+
+def test_logs_crud(test_db):
+    game = create_game(GameCreate(name="Test Game", min_players=4, max_players=6))
+    save_log(game_id=game.id, log="Test log")
+    save_log(game_id=game.id, log="Test log 2")
+    logs = get_logs(game_id=game.id)
+
+    assert logs == [
+        {
+            "date": datetime.now().strftime("%d/%m/%Y %H:%M"),
+            "log": "Test log",
+        },
+        {
+            "date": datetime.now().strftime("%d/%m/%Y %H:%M"),
+            "log": "Test log 2",
+        },
+    ]
+
+
+def test_get_logs_endpoint(test_db):
+    # create a game, add 3 players and start the game
+    game_data = {
+        "game": {"name": "Test Game2", "min_players": 4, "max_players": 6},
+        "host": {"name": "Test Host"},
+    }
+    response = client.post("/game/create", json=game_data)
+    player1_id = response.json()["player_id"]
+    game_id = response.json()["game_id"]
+    player2_id = client.post(
+        "/game/join", json={"player_name": "Test Player 1", "game_id": game_id}
+    ).json()["player_id"]
+    player3_id = client.post(
+        "/game/join", json={"player_name": "Test Player 2", "game_id": game_id}
+    ).json()["player_id"]
+    player4_id = client.post(
+        "/game/join", json={"player_name": "Test Player 3", "game_id": game_id}
+    ).json()["player_id"]
+
+    # start the game
+    client.post("/game/start", json={"game_id": game_id, "player_name": "Test Host"})
+    client.put("/game/steal", json={"player_id": player1_id, "game_id": game_id})
+
+    player1_status = get_player(player1_id, game_id)
+    # get a card that is not kind 5
+    card = next(card for card in player1_status.hand if card.kind not in [3, 4, 5])
+    print(card)
+    # player 1 plays a card to player 2
+    response = client.put(
+        "/game/play",
+        json={
+            "player_id": player1_id,
+            "game_id": game_id,
+            "card_id": card.id,
+            "destination_name": "Test Player 1",
+        },
+    )
+    print(response.json())
+    assert response.status_code == 200
+    response = client.get(f"game/{game_id}/get-logs")
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "date": datetime.now().strftime("%d/%m/%Y %H:%M"),
+            "log": f"Test Host jugó {card.name} a Test Player 1, esperando su respuesta",
+        }
+    ]

--- a/tests/test_player_crud.py
+++ b/tests/test_player_crud.py
@@ -39,7 +39,6 @@ def test_create_player(test_db):
                 "quarantine": False,
             }
         ],
-        "chat": [],
     }
     rollback()
 
@@ -83,7 +82,6 @@ def test_create_wrong_player(test_db):
                 "quarantine": False,
             }
         ],
-        "chat": [],
     }
     rollback()
 
@@ -135,7 +133,6 @@ def test_add_player_to_full_game(test_db):
                     "quarantine": False,
                 },
             ],
-            "chat": [],
         }
     )
     retrieved_game = game_crud.get_game(created_game.id)

--- a/tests/test_turn_crud.py
+++ b/tests/test_turn_crud.py
@@ -37,7 +37,6 @@ def test_create_turn(test_db):
             "state": 0,
         },
         "players": [],
-        "chat": [],
     }
 
 
@@ -77,7 +76,6 @@ def test_update_turn(test_db):
             "state": 1,
         },
         "players": [],
-        "chat": [],
     }
 
     rollback()


### PR DESCRIPTION
Campo en partida para logs creados. 

Se guarda un json que contiene la lista de logs ordenados por fecha y hora. 

Ademas se crean test para los logs. Y se elimina el campo chat de los esquemas de las partidas ya que no es necesario enviarlos todo el tiempo. Para eso esta el endpoint get chat. 

Se crea el endpoint de get logs. Los logs consisten de todo mensaje que se envia en los eventos "action", "defense", "discard".